### PR TITLE
feat(module-loader-commonjs): add proxy support

### DIFF
--- a/packages/module-loader-commonjs/package.json
+++ b/packages/module-loader-commonjs/package.json
@@ -22,6 +22,7 @@
   "typings": "lib/cjs/index.d.ts",
   "dependencies": {
     "@feature-hub/core": "^2.4.1",
+    "https-proxy-agent": "^5.0.0",
     "node-fetch": "^2.6.0"
   },
   "devDependencies": {

--- a/packages/module-loader-commonjs/src/__tests__/index.test.ts
+++ b/packages/module-loader-commonjs/src/__tests__/index.test.ts
@@ -2,16 +2,23 @@
  * @jest-environment node
  */
 
+import createHttpsProxyAgent from 'https-proxy-agent';
+import {RequestInfo, RequestInit} from 'node-fetch';
 import {createCommonJsModuleLoader, loadCommonJsModule} from '..';
 
 let mockResponse: string;
+let requestUrl: RequestInfo;
+let requestInitOptions: RequestInit;
 
 // tslint:disable promise-function-async
-jest.mock('node-fetch', () => () =>
-  Promise.resolve({
+jest.mock('node-fetch', () => (url: RequestInfo, options: RequestInit) => {
+  requestInitOptions = options;
+  requestUrl = url;
+
+  return Promise.resolve({
     text: () => Promise.resolve(Buffer.from(mockResponse))
-  })
-);
+  });
+});
 // tslint:enable promise-function-async
 
 describe('loadCommonJsModule (on Node.js)', () => {
@@ -51,5 +58,31 @@ describe('createCommonJsModuleLoader', () => {
     const expectedModule = {default: {test: 42}};
 
     expect(loadedModule).toEqual(expectedModule);
+  });
+
+  it('sets agent if process.env.HTTP_PROXY is defined', async () => {
+    const currentHttpProxy = process.env.HTTP_PROXY;
+    const url = 'http://example.com/test.js';
+
+    process.env.HTTP_PROXY = 'test';
+    mockResponse = `
+			var foo = require('foo');
+			module.exports = {
+				default: {test: foo()}
+			};
+		`;
+
+    const loadCommonJsModuleWithExternals = createCommonJsModuleLoader({
+      foo: () => 42
+    });
+
+    const loadedModule = await loadCommonJsModuleWithExternals(url);
+    const expectedModule = {default: {test: 42}};
+
+    expect(loadedModule).toEqual(expectedModule);
+    expect(requestUrl).toEqual(url);
+    expect(requestInitOptions).toEqual({agent: createHttpsProxyAgent('test')});
+
+    process.env.HTTP_PROXY = currentHttpProxy;
   });
 });

--- a/packages/module-loader-commonjs/src/index.ts
+++ b/packages/module-loader-commonjs/src/index.ts
@@ -1,5 +1,6 @@
 import {ModuleLoader} from '@feature-hub/core';
-import fetch from 'node-fetch';
+import createHttpsProxyAgent from 'https-proxy-agent';
+import fetch, {RequestInit} from 'node-fetch';
 
 export interface Externals {
   readonly [externalName: string]: unknown;
@@ -9,7 +10,13 @@ export function createCommonJsModuleLoader(
   externals: Externals = {}
 ): ModuleLoader {
   return async (url: string): Promise<unknown> => {
-    const response = await fetch(url);
+    const requestInit: RequestInit = {};
+
+    if (process.env.HTTP_PROXY) {
+      requestInit.agent = createHttpsProxyAgent(process.env.HTTP_PROXY);
+    }
+
+    const response = await fetch(url, requestInit);
     const source = await response.text();
     const mod = {exports: {}};
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2687,6 +2687,13 @@ agent-base@4, agent-base@^4.3.0:
   dependencies:
     es6-promisify "^5.0.0"
 
+agent-base@6:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.0.tgz#5d0101f19bbfaed39980b22ae866de153b93f09a"
+  integrity sha512-j1Q7cSCqN+AwrmDd+pzgqc0/NpC655x2bUf5ZjRIO77DcNBFmh+OgRNzF6OKdCC9RSCb19fGd99+bhXFdkRNqw==
+  dependencies:
+    debug "4"
+
 agent-base@~4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.2.1.tgz#d89e5999f797875674c07d87f260fc41e83e8ca9"
@@ -4782,6 +4789,13 @@ debug@3.1.0:
   dependencies:
     ms "2.0.0"
 
+debug@4, debug@^4.1.0, debug@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
+  dependencies:
+    ms "^2.1.1"
+
 debug@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.0.tgz#373687bffa678b38b1cd91f861b63850035ddc87"
@@ -4793,13 +4807,6 @@ debug@^3.1.0, debug@^3.2.5, debug@^3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
-  dependencies:
-    ms "^2.1.1"
-
-debug@^4.1.0, debug@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
-  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
 
@@ -7012,6 +7019,14 @@ https-proxy-agent@^2.2.1:
   dependencies:
     agent-base "^4.3.0"
     debug "^3.1.0"
+
+https-proxy-agent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2"
+  integrity sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==
+  dependencies:
+    agent-base "6"
+    debug "4"
 
 humanize-ms@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
Die Server-Konfiguration des Header-Service setzt voraus, dass Feature-App-Artefakte via Proxy geladen werden.

Daher muss `node-fetch` um einen HTTPS-Proxy-Agent erweitert werden, der Konfigurationen aus der `process.env.HTTP_PROXY` Variable liest und diese an `node-fetch` übergibt.

### How to test
`npm run test`