### PR TITLE
refactor/update namespace

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@das-buro-am-draht:registry=https://npm.pkg.github.com/

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "feature-hub",
+  "name": "@das-buro-am-draht/feature-hub",
   "private": true,
   "license": "MIT",
   "workspaces": [
@@ -21,15 +21,15 @@
     "verify": "run-p verify:**",
     "verify:format": "prettier --list-different '**/*.{js,json,md,ts,tsx,yml}'",
     "verify:install": "git diff --exit-code yarn.lock",
-    "verify:size-limit": "lerna exec --no-private --ignore @feature-hub/module-loader-commonjs --parallel -- size-limit",
+    "verify:size-limit": "lerna exec --no-private --ignore @das-buro-am-draht/module-loader-commonjs --parallel -- size-limit",
     "preverify:sort-package-jsons": "yarn sort-package-jsons",
     "verify:sort-package-jsons": "git diff --exit-code package.json packages/*/package.json",
     "watch:compile": "lerna exec --parallel -- tsc --project tsconfig.cjs.json --watch --preserveWatchOutput --pretty",
-    "watch:demo": "lerna exec --scope @feature-hub/demos -- ts-node -r tsconfig-paths/register src/watch-demo.ts",
+    "watch:demo": "lerna exec --scope @das-buro-am-draht/demos -- ts-node -r tsconfig-paths/register src/watch-demo.ts",
     "watch:test": "yarn test --watch --no-coverage --no-verbose",
     "watch:test:integration": "yarn watch:test --testPathPattern packages/demos",
     "watch:test:unit": "yarn watch:test --testPathIgnorePatterns packages/demos",
-    "watch:website": "lerna exec --scope @feature-hub/website -- docusaurus-start"
+    "watch:website": "lerna exec --scope @das-buro-am-draht/website -- docusaurus-start"
   },
   "devDependencies": {
     "@babel/core": "^7.2.2",

--- a/packages/async-ssr-manager/package.json
+++ b/packages/async-ssr-manager/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@feature-hub/async-ssr-manager",
+  "name": "@das-buro-am-draht/async-ssr-manager",
   "version": "2.4.1",
   "description": "A Feature Service to manage asynchronous server-side rendering.",
   "homepage": "https://feature-hub.io/",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@feature-hub/core",
+  "name": "@das-buro-am-draht/core",
   "version": "2.4.1",
   "description": "Create scalable web applications using micro frontends.",
   "keywords": [

--- a/packages/demos/package.json
+++ b/packages/demos/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@feature-hub/demos",
+  "name": "@das-buro-am-draht/demos",
   "version": "2.5.0",
   "private": true,
   "license": "MIT",

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@feature-hub/dom",
+  "name": "@das-buro-am-draht/dom",
   "version": "2.4.1",
   "description": "A library for building a Feature Hub integrator using Web Components.",
   "homepage": "https://feature-hub.io/",

--- a/packages/history-service/package.json
+++ b/packages/history-service/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@feature-hub/history-service",
+  "name": "@das-buro-am-draht/history-service",
   "version": "2.4.1",
   "description": "A history facade guaranteeing safe access for multiple consumers.",
   "homepage": "https://feature-hub.io/",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@feature-hub/logger",
+  "name": "@das-buro-am-draht/logger",
   "version": "2.4.1",
   "description": "A Feature Service for providing a common logging integration to all Feature Hub consumers.",
   "homepage": "https://feature-hub.io/",

--- a/packages/module-loader-amd/package.json
+++ b/packages/module-loader-amd/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@feature-hub/module-loader-amd",
+  "name": "@das-buro-am-draht/module-loader-amd",
   "version": "2.4.1",
   "description": "A FeatureAppManager-compatible AMD module loader.",
   "homepage": "https://feature-hub.io/",

--- a/packages/module-loader-commonjs/package.json
+++ b/packages/module-loader-commonjs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@feature-hub/module-loader-commonjs",
+  "name": "@das-buro-am-draht/module-loader-commonjs",
   "version": "2.4.1",
   "description": "A FeatureAppManager-compatible CommonJS module loader.",
   "homepage": "https://feature-hub.io/",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@feature-hub/react",
+  "name": "@das-buro-am-draht/react",
   "version": "2.5.0",
   "description": "A library for building a Feature Hub integrator with React.",
   "homepage": "https://feature-hub.io/",

--- a/packages/serialized-state-manager/package.json
+++ b/packages/serialized-state-manager/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@feature-hub/serialized-state-manager",
+  "name": "@das-buro-am-draht/serialized-state-manager",
   "version": "2.4.1",
   "description": "A Feature Service for managing the state transfer to the client when rendering on the server.",
   "homepage": "https://feature-hub.io/",

--- a/packages/server-request/package.json
+++ b/packages/server-request/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@feature-hub/server-request",
+  "name": "@das-buro-am-draht/server-request",
   "version": "2.4.1",
   "description": "A Feature Service that provides a server request to consumers that want to be server-side rendered.",
   "homepage": "https://feature-hub.io/",

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@feature-hub/website",
+  "name": "@das-buro-am-draht/website",
   "version": "2.2.0",
   "private": true,
   "license": "MIT",

--- a/scripts/netlify/build-website.sh
+++ b/scripts/netlify/build-website.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-yarn lerna exec --scope @feature-hub/website 'rm -rf build'
-yarn lerna exec --scope @feature-hub/website 'docusaurus-build'
+yarn lerna exec --scope @das-buro-am-draht/website 'rm -rf build'
+yarn lerna exec --scope @das-buro-am-draht/website 'docusaurus-build'
 yarn run generate:api-docs
-yarn lerna run --scope @feature-hub/demos build:todomvc
+yarn lerna run --scope @das-buro-am-draht/demos build:todomvc

--- a/scripts/process-api-docs.js
+++ b/scripts/process-api-docs.js
@@ -6,7 +6,7 @@ const updateHtmlFile = require('./update-html-file');
 
 const apiDocsDirname = path.join(
   __dirname,
-  '../packages/website/build/feature-hub/@feature-hub'
+  '../packages/website/build/feature-hub/@das-buro-am-draht'
 );
 
 // Rename "External Modules" to "Packages" on the index page.

--- a/typedoc.js
+++ b/typedoc.js
@@ -12,8 +12,8 @@ module.exports = {
   gitRevision: 'master',
   ignoreCompilerErrors: false,
   mode: 'modules',
-  name: '@feature-hub',
-  out: 'packages/website/build/feature-hub/@feature-hub',
+  name: '@das-buro-am-draht',
+  out: 'packages/website/build/feature-hub/@das-buro-am-draht',
   readme: 'README.md',
   theme: 'minimal',
   tsconfig: 'tsconfig.json'


### PR DESCRIPTION
Da wir Pakete veröffentlichen werden ist es nötig, die Namespaces zu ändern.

Unsere private NPM Registry sollte durch Hinzufügen der `.npmrc` angesteuert werden.